### PR TITLE
generate tempfiles on default place

### DIFF
--- a/extract_features_expression.py
+++ b/extract_features_expression.py
@@ -438,7 +438,7 @@ def main(inputfile, type, folder, overall_parameters={},log=False):
         files.append(inputfile)
         
         #Output FD will be a temporary file
-        output_fd = tempfile.NamedTemporaryFile('w', dir=folder, delete=False)
+        output_fd = tempfile.NamedTemporaryFile('w', delete=False)
     elif type == 'test':
         parameter_filename = os.path.join(folder,PARAMETERS_FILENAME)
         fd_param = open(parameter_filename,'r')

--- a/extract_features_holder.py
+++ b/extract_features_holder.py
@@ -374,7 +374,7 @@ def main(inputfile, this_type, folder, overall_parameters = {}, detected_dse = {
         files.append(inputfile)
         
         #Output FD will be a temporary file
-        output_fd = tempfile.NamedTemporaryFile('w', dir=folder, delete=False)
+        output_fd = tempfile.NamedTemporaryFile('w', delete=False)
     elif this_type == 'test':
         parameter_filename = os.path.join(folder,PARAMETERS_FILENAME)
         fd_param = open(parameter_filename,'r')

--- a/extract_features_target.py
+++ b/extract_features_target.py
@@ -334,7 +334,7 @@ def main(inputfile, this_type, folder, overall_parameters = {}, detected_dse = {
         files.append(inputfile)
         
         #Output FD will be a temporary file
-        output_fd = tempfile.NamedTemporaryFile('w', dir=folder, delete=False)
+        output_fd = tempfile.NamedTemporaryFile('w', delete=False)
     elif this_type == 'test':
         parameter_filename = os.path.join(folder,PARAMETERS_FILENAME)
         fd_param = open(parameter_filename,'r')


### PR DESCRIPTION
Hi Ruben,
I saw that the opinion miner generated temporary files  in the model-directories. However, this causes problems e.g. when another user than the person who installed it tries to run the opinion-miner. Therefore I propose to remove the "directory" arguments in the function calls to generate tempfiles.

Cheers,

Paul.
