### PR TITLE
generate tempfile on default location

### DIFF
--- a/extract_features_expression.py
+++ b/extract_features_expression.py
@@ -462,7 +462,7 @@ def main(inputfile, type, folder, overall_parameters={},log=False):
         files.append(inputfile)
         
         #Output FD will be a temporary file
-        output_fd = tempfile.NamedTemporaryFile('w', dir=folder, delete=False)
+        output_fd = tempfile.NamedTemporaryFile('w', delete=False)
     elif type == 'test':
         parameter_filename = os.path.join(folder,PARAMETERS_FILENAME)
         fd_param = open(parameter_filename,'r')


### PR DESCRIPTION
Hi Ruben,

The opinion-miner tries to generate a temporary file in a subdirectory of the module. In many cases the user has no rights or possibility to do that. Therefore  I changed this to use the default location (to be determined by the environment, OS). If you agree with this, would you apply it?

Thanks,
Paul
